### PR TITLE
change dvim image to alpine based

### DIFF
--- a/docker/dvim/local/Dockerfile
+++ b/docker/dvim/local/Dockerfile
@@ -1,4 +1,4 @@
-FROM mshytikov/dvim:latest
+FROM g1ddriver/dvim:latest
 
 ARG UID
 


### PR DESCRIPTION
g1ddriver/dvim:latest was build on alpine base image instead of ubuntu the same way as mshytikov/dvim. Resulting image is ~350Mb.

Needs testing